### PR TITLE
CSS to Hide original Image tag when image fails to load

### DIFF
--- a/src/Img.svelte
+++ b/src/Img.svelte
@@ -69,6 +69,9 @@
     opacity: 1;
     transition: opacity 250ms ease-out;
   }
+  .hide {
+    display: none;
+  }
 </style>
 
 <div
@@ -83,6 +86,7 @@
     {...$$restProps}
     bind:this={img}
     class:loading={loading && mounted}
+    class:hide={error}
     on:click
     on:mouseover
     on:mouseenter


### PR DESCRIPTION
In my testing when an image fails to load the original image tag called inside of the img.svelte is still loaded onto the page. 